### PR TITLE
Add .gitlab-ci.yml file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,25 @@
+test:
+  stage: test
+  script:
+    - whoami
+    - pwd
+    - env
+    - $RAILS_DEPLOY_PATH/bin/test.sh
+  tags: development
+
+deploy_dev:
+  environment:
+    name: development
+    url: https://trln-discovery-dev.lib.duke.edu
+  stage: deploy
+  script:
+    - whoami
+    - pwd
+    - env
+    - $RAILS_DEPLOY_PATH/bin/deploy.sh $CI_PROJECT_DIR
+  after_script:
+    - $RAILS_DEPLOY_PATH/bin/after_deploy.sh
+  only:
+    - master
+  tags:
+    - development


### PR DESCRIPTION
Enable GitLab CI/CD for this project by adding the necessary
configuration file to the root of the repository.

To start with, there will be two jobs: one to run the test, and
another to deploy the code to the development environment.