### PR TITLE
Downgrade Sass from 3.7.0 to 3.6.0 to circumvent precompile bug https…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
       rubocop (>= 0.58.0)
     ruby-progressbar (1.10.0)
     rubyzip (1.2.2)
-    sass (3.7.0)
+    sass (3.6.0)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)

--- a/lib/dul_argon_skin/version.rb
+++ b/lib/dul_argon_skin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DulArgonSkin
-  VERSION = '0.1.10'
+  VERSION = '0.1.11'
 end


### PR DESCRIPTION
…://github.com/sass/ruby-sass/issues/94.