### PR TITLE
Refine LC Call Number Searching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ gem 'lcsort', '~> 0.9'
 gem 'trln_argon', git: 'https://github.com/trln/trln_argon'
 
 group :development, :test do
+  gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 3.8'
   gem 'rubocop', '~> 0.58.2'
   gem 'rubocop-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.0.7)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -307,6 +311,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   puma (~> 3.0)
   rails (~> 5.0.1)
+  rails-controller-testing
   rspec-rails (~> 3.8)
   rubocop (~> 0.58.2)
   rubocop-rspec

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -30,9 +30,7 @@ class CatalogController < ApplicationController
     ## Default parameters to send to solr for all search-like requests.
     #  See also SearchBuilder#processed_parameters
     config.default_solr_params = {
-      rows: 10,
-      uf: '-*',
-      sow: true
+      rows: 10
     }
 
     # solr path which will be added to solr base url before other solr params

--- a/app/models/concerns/shelfkey_search_builder.rb
+++ b/app/models/concerns/shelfkey_search_builder.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ShelfkeySearchBuilder
+  extend ActiveSupport::Concern
+
+  def add_shelfkey_query_to_solr(solr_parameters)
+    return unless shelfkey_query_present?
+    solr_parameters[:uf] = 'shelfkey'
+    solr_parameters[:defType] = 'lucene'
+    solr_parameters[:q] = shelfkey_query
+  end
+
+  private
+
+  def shelfkey_query_present?
+    blacklight_params.key?('search_field') &&
+      blacklight_params['search_field'] == 'shelfkey' &&
+      blacklight_params[:q].present? &&
+      blacklight_params[:q].respond_to?(:to_str)
+  end
+
+  def normalized_shelfkey
+    @normalized_shelfkey ||= Lcsort.normalize(blacklight_params[:q].to_s) ||
+                             blacklight_params[:q].to_s
+  end
+
+  # Generate fielded regex query for Solr.
+  # Regex fussiness at the end is to force the last
+  # segment to match completely.
+  def shelfkey_query
+    "shelfkey:/lc:#{normalized_shelfkey.split('--').first}(\\..*|-.*)*/"
+  end
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -6,25 +6,10 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
   include TrlnArgon::ArgonSearchBuilder
+  include DulArgonSkin::ShelfkeySearchBuilder
 
   self.default_processor_chain += %i[add_advanced_search_to_solr
                                      add_shelfkey_query_to_solr]
-
-  def add_shelfkey_query_to_solr(solr_parameters)
-    return unless shelfkey_query_present?
-    solr_parameters[:q] = '{!edismax qf=shelfkey_t pf=shelfkey_t}'\
-                          "lc\\:#{Lcsort.normalize(blacklight_params[:q].to_s)}"
-    solr_parameters[:defType] = 'lucene'
-  end
-
-  private
-
-  def shelfkey_query_present?
-    blacklight_params.key?('search_field') &&
-      blacklight_params['search_field'] == 'shelfkey' &&
-      blacklight_params[:q].present? &&
-      blacklight_params[:q].respond_to?(:to_str)
-  end
 
   ##
   # @example Adding a new step to the processor chain

--- a/lib/dul_argon_skin/version.rb
+++ b/lib/dul_argon_skin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DulArgonSkin
-  VERSION = '0.2.10'
+  VERSION = '0.2.11'
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -15,4 +15,87 @@ describe CatalogController do
       end
     end
   end
+
+  describe 'shelfkey queries' do
+    before { skip('Skipping call number tests. Useful but brittle.') }
+
+    it 'finds HT127.5 .S465' do
+      get :index, params: { q: 'HT127.5 .S465', search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to include('DUKE004209367')
+    end
+
+    it 'finds P123 .J34 1974 c.1' do
+      get :index, params: { q: 'P123 .J34 1974 c.1', search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to include('DUKE000547802')
+    end
+
+    it 'finds P123 .J34 1972' do
+      get :index, params: { q: 'P123 .J34 1972', search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to include('DUKE001353979')
+    end
+
+    it 'finds P123 .J34' do
+      get :index, params: { q: 'P123 .J34', search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to include('DUKE001353979')
+    end
+
+    it 'finds LB2351.2 .S755 2007' do
+      get :index, params: { q: 'LB2351.2 .S755 2007', search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to include('DUKE003897886')
+    end
+
+    it 'finds LB2351.2 .S755 2007 c.1' do
+      get :index, params: { q: 'LB2351.2 .S755 2007 c.1',
+                            search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to include('DUKE003897886')
+    end
+
+    it 'finds LB2351.2 .S755' do
+      get :index, params: { q: 'LB2351.2 .S755', search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to include('DUKE003897886')
+    end
+
+    it 'finds DD207.5 .M26 1975 Bd.2 c.1' do
+      get :index, params: { q: 'DD207.5 .M26 1975 Bd.2 c.1',
+                            search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to include('DUKE000205600')
+    end
+
+    it 'finds DD207.5 .M26 1975' do
+      get :index, params: { q: 'DD207.5 .M26 1975', search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to include('DUKE000205600')
+    end
+
+    it 'does not find PS3537 A83' do
+      get :index, params: { q: 'PS3537 A83', search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to eq([])
+    end
+
+    it 'finds all matches for PS3537.A832' do
+      get :index, params: { q: 'PS3537.A832', search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id).count).to be > 10
+    end
+
+    it 'finds PS3563.O8749 B4' do
+      get :index, params: { q: 'PS3563.O8749 B4', search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to include('DUKE000738630')
+    end
+
+    it 'does not find partials of PS3563.O8749 B4' do
+      get :index, params: { q: 'PS3563.O8749 B4', search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).not_to include('DUKE007451897')
+    end
+
+    it 'finds PS3563.O8749 B4 2006' do
+      get :index, params: { q: 'PS3563.O8749 B4 2006',
+                            search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to include('DUKE003835769')
+    end
+
+    it 'finds PS3563.O8749 B4 1998b c.3' do
+      get :index, params: { q: 'PS3563.O8749 B4 1998b c.3',
+                            search_field: 'shelfkey' }
+      expect(assigns(:document_list).map(&:id)).to include('DUKE002544061')
+    end
+  end
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -17,18 +17,33 @@ describe SearchBuilder do
       builder_with_params.add_shelfkey_query_to_solr(solr_parameters)
     end
 
-    let(:builder_with_params) do
-      subject.with(q: 'PJ709 .G533', 'search_field' => 'shelfkey')
+    context 'with a basic call number' do
+      let(:builder_with_params) do
+        subject.with(q: 'PJ709 .G533', 'search_field' => 'shelfkey')
+      end
+
+      it 'assembles the shelfkey query' do
+        expect(solr_parameters[:q]).to(
+          eq('shelfkey:/lc:PJ.0709.G533(\\..*|-.*)*/')
+        )
+      end
+
+      it 'sets the defType to lucene' do
+        expect(solr_parameters[:defType]).to eq('lucene')
+      end
     end
 
-    it 'assembles the shelfkey query' do
-      expect(solr_parameters[:q]).to(
-        eq('{!edismax qf=shelfkey_t pf=shelfkey_t}lc\\:PJ.0709.G533')
-      )
-    end
+    context 'with a call number that includes volume or copy info' do
+      let(:builder_with_params) do
+        subject.with(q: 'DD207.5 .M26 1975 Bd.2 c.1',
+                     'search_field' => 'shelfkey')
+      end
 
-    it 'sets the defType to lucene' do
-      expect(solr_parameters[:defType]).to eq('lucene')
+      it 'assembles the shelfkey query without volume/copy info' do
+        expect(solr_parameters[:q]).to(
+          eq('shelfkey:/lc:DD.02075.M26.1975(\\..*|-.*)*/')
+        )
+      end
     end
   end
 


### PR DESCRIPTION
* I've skipped all the shelfkey/call number tests that actually run queries against Solr because they're slow and likely brittle. Keeping them around for future troubleshooting purposes.
* Removing a couple of default Solr parameters (sow & uf) because these are now being set by Solr itself.