### PR TITLE
Add production deployment to GitLab CI/CD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,3 +39,17 @@ deploy_pre:
     - master
   tags:
     - staging
+
+deploy_prod:
+  environment:
+    name: production
+    url: https://find.library.duke.edu
+  stage: deploy
+  before_script: *beforedeployscript
+  script: *deployscript
+  after_script: *afterdeployscript
+  only:
+    - master
+  when: manual
+  tags:
+    - production


### PR DESCRIPTION
Adds a new job to .gitlab-ci.yml to deploy commits on the master branch
to the production environment using the same deployment process used in
development and staging. These deployment jobs will be held in the GitLab
CI/CD queue until released manually.