### PR TITLE
Displays multiple links more cleanly:

### DIFF
--- a/app/assets/javascripts/dul-argon-skin.js
+++ b/app/assets/javascripts/dul-argon-skin.js
@@ -86,10 +86,17 @@ $(document).ready(function() {
   });
 
 
+  /* position tooltips */
+  $("#holdings ul.single-link a").tooltip({placement : 'right'});
+  $("#holdings button.link-type-fulltext").tooltip({placement : 'right'});
+  $("#documents ul.single-link a").tooltip({placement : 'right'});
+  $("#documents button.link-type-fulltext").tooltip({placement : 'right'});
+
   /* enable tooltips*/
   $(function () {
     $('[data-toggle="tooltip"]').tooltip()
   });
+
 
   /* When the Request button is clicked for a TRLN result, show */
   /* a modal with links to choose your home library. Add the    */
@@ -203,6 +210,7 @@ $(document).ready(function() {
   };
 
 });
+
 
 /* Add classes to the search results titles depending on whether they have */
 /* thumbnails, request buttons, both, or neither */

--- a/app/assets/stylesheets/dul_argon/search-results.scss
+++ b/app/assets/stylesheets/dul_argon/search-results.scss
@@ -232,6 +232,22 @@ div.primary-url {
     }
   }
 
+  .primary-url ul.multiple-links-institution,
+  .primary-url ul.multiple-links {
+    display: flex;
+    flex-wrap: wrap;
+    li {
+      flex: 0 calc(50% - 10px);
+      text-align: center;
+    }
+    li:nth-child(odd) {
+      margin-right: 5px;
+    }
+    li:nth-child(even) {
+      margin-left: 5px;
+    }
+  }
+
 }
 
 
@@ -272,4 +288,13 @@ div.primary-url {
 
 .items-wrapper .location-narrow-group {
   overflow: hidden;
+}
+
+.modal-button-wrapper {
+  display: inline-block;
+}
+
+#documents .modal-body .primary-url {
+  width: 100% !important;
+  margin: 0 !important;
 }

--- a/app/helpers/trln_argon_helper.rb
+++ b/app/helpers/trln_argon_helper.rb
@@ -3,11 +3,6 @@
 module TrlnArgonHelper
   include TrlnArgon::ViewHelpers::TrlnArgonHelper
 
-  def link_to_fulltext_url(url_hash)
-    return if url_hash[:href].blank?
-    link_to_others(url_hash)
-  end
-
   def link_to_finding_aid(url_hash)
     link_icon = '<i class="fa fa-archive" aria-hidden="true"></i>'
     link_to(url_hash[:href],
@@ -17,15 +12,72 @@ module TrlnArgonHelper
             end
   end
 
-  def link_to_others(url_hash)
+  def link_to_fulltext_url(url_hash, options = {})
+    return if url_hash[:href].blank?
     inst = TrlnArgon::Engine.configuration.local_institution_code
     link_icon = '<i class="fa fa-external-link" aria-hidden="true"></i>'
+    if options[:link_type] == 'multiple'
+      fulltext_without_tooltip(url_hash, link_icon, inst)
+    else
+      fulltext_with_tooltip(url_hash, link_icon, inst)
+    end
+  end
+
+  def fulltext_with_tooltip(url_hash, link_icon, inst)
     link_to(url_hash[:href],
             class: "link-type-#{url_hash[:type]} link-restricted-#{inst}",
             target: '_blank', title: fulltext_link_text(url_hash),
-            data: { toggle: 'tooltip', placement: 'right' }) do
+            data: { toggle: 'tooltip' }) do
               link_icon.html_safe + t('trln_argon.links.online_access')
             end
+  end
+
+  def fulltext_without_tooltip(url_hash, link_icon, inst)
+    link_to(url_hash[:href],
+            class: "link-type-#{url_hash[:type]} link-restricted-#{inst}",
+            target: '_blank') do
+              link_icon.html_safe + fulltext_link_text(url_hash)
+            end
+  end
+
+  def link_to_expanded_fulltext_url(url_hash, inst, options = {})
+    return if url_hash[:href].blank?
+    if options[:link_type] == 'multiple'
+      expanded_without_tooltip(url_hash, inst)
+    else
+      expanded_with_tooltip(url_hash, inst)
+    end
+  end
+
+  def expanded_with_tooltip(url_hash, inst)
+    link_to(url_hash[:href],
+            class: "link-type-#{url_hash[:type]} link-restricted-#{inst}",
+            target: '_blank', title: fulltext_link_text(url_hash),
+            data: { toggle: 'tooltip' }) do
+      '<i class="fa fa-external-link" aria-hidden="true"></i>'.html_safe +
+        expanded_fulltext_link_text(inst)
+    end
+  end
+
+  def expanded_without_tooltip(url_hash, inst)
+    link_to(url_hash[:href],
+            class: "link-type-#{url_hash[:type]} link-restricted-#{inst}",
+            target: '_blank') do
+      '<i class="fa fa-external-link" aria-hidden="true"></i>'.html_safe +
+        fulltext_link_text(url_hash)
+    end
+  end
+
+  def fulltext_link_text(url_hash)
+    if url_hash[:note].present? && url_hash[:text].present?
+      "#{url_hash[:text]} — #{url_hash[:note]}"
+    elsif url_hash[:note].present?
+      url_hash[:note]
+    elsif url_hash[:text].present?
+      url_hash[:text]
+    else
+      I18n.t('trln_argon.links.online_access')
+    end
   end
 
   def show_class

--- a/app/views/catalog/_fulltext_links.html.erb
+++ b/app/views/catalog/_fulltext_links.html.erb
@@ -1,0 +1,97 @@
+<% if document.fulltext_urls.any? || document.shared_fulltext_urls.any? || document.open_access_urls.any? %>
+
+  <% if document.fulltext_urls.any? %>
+
+    <% if document.fulltext_urls.count > 1 %>
+
+      <div class="col-md-7 primary-url">
+        <div class="modal-button-wrapper" data-toggle="modal" data-target="#modal_<%= document.id %>">
+          <button type="button" class="link-type-fulltext" data-toggle="tooltip" data-original-title="<%= t('trln_argon.links.online_access_all') %>">
+            <i class="fa fa-external-link" aria-hidden="true"></i> <%= t('trln_argon.links.online_access') %>
+          </button>
+        </div>
+      </div>
+
+      <!-- Modal -->
+      <div class="modal fade" id="modal_<%= document.id %>" tabindex="-1" role="dialog" aria-labelledby="modal_<%= document.id %>_label">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+              <h4 class="modal-title" id="modal_<%= document.id %>_label"><%= t('trln_argon.links.online_access_all') %></h4>
+            </div>
+            <div class="modal-body">
+
+              <div class="<%= primary_link_class %>">
+                <ul class="multiple-links">
+                <% document.fulltext_urls.each do |url| %>
+                  <li><%= link_to_fulltext_url(url, link_type: 'multiple') %></li>
+                <% end %>
+                </ul>
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+
+    <% else %>
+
+      <div class="<%= primary_link_class %>">
+        <ul class="single-link">
+          <li><%= link_to_fulltext_url(document.fulltext_urls.first) %></li>
+        </ul>
+      </div>
+
+    <% end %>
+
+
+  <% elsif document.shared_fulltext_urls.any? %>
+
+    <% if document.shared_fulltext_urls.count > 1 %>
+
+      <div class="col-md-7 primary-url <%= primary_link_class %>">
+        <div class="modal-button-wrapper" data-toggle="modal" data-target="#modal_<%= document.id %>">
+          <button type="button" class="link-type-fulltext" data-toggle="tooltip" data-original-title="<%= t('trln_argon.links.online_access_all') %>">
+            <i class="fa fa-external-link" aria-hidden="true"></i> <%= t('trln_argon.links.online_access') %>
+          </button>
+        </div>
+      </div>
+
+      <!-- Modal -->
+      <div class="modal fade" id="modal_<%= document.id %>" tabindex="-1" role="dialog" aria-labelledby="modal_<%= document.id %>_label">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+              <h4 class="modal-title" id="modal_<%= document.id %>_label"><%= t('trln_argon.links.online_access_all') %></h4>
+            </div>
+            <div class="modal-body">
+
+              <div class="primary-url <%= primary_link_class %>">
+                <ul class="multiple-links">
+                <% document.shared_fulltext_urls.each do |url| %>
+                  <li><%= link_to_fulltext_url(url, link_type: 'multiple') %></li>
+                <% end %>
+                </ul>
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+
+    <% else %>
+
+      <div class="primary-url <%= primary_link_class %>">
+        <ul class="single-link">
+          <li><%= link_to_fulltext_url(document.shared_fulltext_urls.first) %></li>
+        </ul>
+      </div>
+
+    <% end %>
+  <% end %>
+  <%= render partial: 'open_access_links', locals: { document: document } %>
+<% else %>
+  <%= render partial: 'hathitrust_link', locals: { document: document } %>
+<% end %>

--- a/app/views/catalog/_open_access_links.html.erb
+++ b/app/views/catalog/_open_access_links.html.erb
@@ -1,0 +1,56 @@
+<% if document.open_access_urls.any? %>
+
+  <% if document.open_access_urls.count > 1 %>
+
+    <div class="col-md-7 primary-url">
+      <div class="modal-button-wrapper" data-toggle="modal" data-target="#modal_<%= document.id %>">
+        <button type="button" class="link-type-fulltext" data-toggle="tooltip" data-original-title="<%= t('trln_argon.links.open_access_all') %>">
+          <i class="fa fa-external-link" aria-hidden="true"></i> <%= t('trln_argon.links.open_access') %>
+        </button>
+      </div>
+    </div>
+
+    <!-- Modal -->
+    <div class="modal fade" id="modal_<%= document.id %>" tabindex="-1" role="dialog" aria-labelledby="modal_<%= document.id %>_label">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title" id="modal_<%= document.id %>_label"><%= t('trln_argon.links.open_access_all') %></h4>
+          </div>
+          <div class="modal-body">
+
+            <div class="<%= primary_link_class %>">
+              <ul class="multiple-links">
+                <% document.open_access_urls.each do |urls| %>
+                  <% next unless urls.present? %>
+                    <li>
+                      <%= link_to_open_access(urls) %>
+                      <%= render partial: "url_note", locals: { url_hash: urls } %>
+                    </li>
+                <% end %>
+              </ul>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+
+  <% else %>
+
+    <div class="<%= primary_link_class %>">
+      <ul class="single-link">
+        <% document.open_access_urls.each do |urls| %>
+          <% next unless urls.present? %>
+            <li>
+              <%= link_to_open_access(urls) %>
+              <%= render partial: "url_note", locals: { url_hash: urls } %>
+            </li>
+        <% end %>
+      </ul>
+    </div>
+
+  <% end %>
+
+<% end %>

--- a/app/views/trln/_expanded_fulltext_links.html.erb
+++ b/app/views/trln/_expanded_fulltext_links.html.erb
@@ -1,0 +1,55 @@
+<% if document.all_shared_and_local_fulltext_urls_by_inst.fetch(inst, []).to_a.any? %>
+
+  <% if document.all_shared_and_local_fulltext_urls_by_inst.fetch(inst, []).to_a.count > 1 %>
+
+    <div class="col-md-7 primary-url">
+      <div class="modal-button-wrapper" data-toggle="modal" data-target="#modal_<%= document.id %>_<%= inst %>">
+        <button type="button" class="link-type-fulltext" data-toggle="tooltip" data-original-title="<%= t('trln_argon.links.online_access_all') %>">
+          <i class="fa fa-external-link" aria-hidden="true"></i> <%= expanded_fulltext_link_text(inst) %>
+        </button>
+      </div>
+    </div>
+
+    <!-- Modal -->
+    <div class="modal fade" id="modal_<%= document.id %>_<%= inst %>" tabindex="-1" role="dialog" aria-labelledby="modal_<%= document.id %>_<%= inst %>_label">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title" id="modal_<%= document.id %>_<%= inst %>_label"><%= t('trln_argon.links.online_access_all') %></h4>
+          </div>
+          <div class="modal-body">
+
+            <div class="<%= primary_link_class %>">
+              <ul class="multiple-links-institution">
+
+                <% document.all_shared_and_local_fulltext_urls_by_inst.fetch(inst, []).to_a.each do |url| %>
+                  <% next unless url.present? %>
+                    <li>
+                      <%= link_to_expanded_fulltext_url(url, inst, link_type: 'multiple') %>
+                    </li>
+                <% end %>
+
+              </ul>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+
+  <% else %>
+
+    <div class="<%= primary_link_class %>">
+      <ul class="single-link">
+        <% document.all_shared_and_local_fulltext_urls_by_inst.fetch(inst, []).to_a.each do |url| %>
+          <% next unless url.present? %>
+            <li>
+              <%= link_to_expanded_fulltext_url(url, inst) %>
+            </li>
+        <% end %>
+      </ul>
+    </div>
+
+  <% end %>
+<% end %>

--- a/app/views/trln/_open_access_links.html.erb
+++ b/app/views/trln/_open_access_links.html.erb
@@ -1,0 +1,55 @@
+<% if document.all_open_access_urls_by_inst.fetch(inst, []).to_a.any? %>
+
+  <% if document.all_open_access_urls_by_inst.fetch(inst, []).to_a.count > 1 %>
+
+    <div class="col-md-7 primary-url">
+      <div class="modal-button-wrapper" data-toggle="modal" data-target="#modal_<%= document.id %>_<%= inst %>">
+        <button type="button" class="link-type-fulltext" data-toggle="tooltip" data-original-title="<%= t('trln_argon.links.open_access_all') %>">
+          <i class="fa fa-external-link" aria-hidden="true"></i> <%= expanded_fulltext_link_text(inst) %>
+        </button>
+      </div>
+    </div>
+
+    <!-- Modal -->
+    <div class="modal fade" id="modal_<%= document.id %>_<%= inst %>" tabindex="-1" role="dialog" aria-labelledby="modal_<%= document.id %>_<%= inst %>_label">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title" id="modal_<%= document.id %>_<%= inst %>_label"><%= t('trln_argon.links.open_access_all') %></h4>
+          </div>
+          <div class="modal-body">
+
+            <div class="<%= primary_link_class %>">
+              <ul class="multiple-links-institution">
+
+                <% document.all_open_access_urls_by_inst.fetch(inst, []).to_a.each do |url| %>
+                  <% next unless url.present? %>
+                    <li>
+                      <%= expanded_link_to_open_access(url) %>
+                    </li>
+                <% end %>
+
+              </ul>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+
+  <% else %>
+
+    <div class="<%= primary_link_class %>">
+      <ul class="single-link">
+        <% document.all_open_access_urls_by_inst.fetch(inst, []).to_a.each do |url| %>
+          <% next unless url.present? %>
+            <li>
+              <%= expanded_link_to_open_access(url) %>
+            </li>
+        <% end %>
+      </ul>
+    </div>
+
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,7 +47,9 @@ en:
       hathitrust: "View Online"
       online_access: "View Online"
       online_access_restricted: "View Online (%{institution} Only)"
+      online_access_all: "View All Online Links"
       open_access: "View Online"
+      open_access_all: "View All Online Links"
     local_filter:
       searching_trln: 'Duke, UNC, NCSU, NCCU Libraries'
     map_location:

--- a/lib/dul_argon_skin/version.rb
+++ b/lib/dul_argon_skin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DulArgonSkin
-  VERSION = '0.3.18'
+  VERSION = '0.3.19'
 end

--- a/spec/helpers/trln_argon_helper_spec.rb
+++ b/spec/helpers/trln_argon_helper_spec.rb
@@ -17,7 +17,7 @@ describe TrlnArgonHelper do
         '<a class="link-type-fulltext link-restricted-duke" '\
         'target="_blank" '\
          'title="Law and contemporary problems, v. 63, no. 1-2" '\
-         'data-toggle="tooltip" data-placement="right" '\
+         'data-toggle="tooltip" '\
          'href="http://www.law.duke.edu/journals/lcp/">'\
          '<i class="fa fa-external-link" aria-hidden="true">'\
          '</i>View Online</a>'
@@ -39,7 +39,6 @@ describe TrlnArgonHelper do
         '<a class="link-type-fulltext link-restricted-duke" '\
         'target="_blank" '\
         'title="View Online" data-toggle="tooltip" '\
-        'data-placement="right" '\
         'href="http://www.law.duke.edu/journals/lcp/">'\
         '<i class="fa fa-external-link" '\
         'aria-hidden="true"></i>View Online</a>'


### PR DESCRIPTION
- for items with multiple links, a button gets rendered that looks like default link, but has tooltip text as 'View All Online Links' and opens a modal using a unique ID
- the modal displays all of the links arranged in responsive columns with link text and/or notes; tooltips are not used
- adds new template overrides in /app/views/trln/
- resolves https://duldev.atlassian.net/browse/TRLNDSC-67