### PR TITLE
Add report missing item link to full record page.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
+gem 'addressable', '~> 2.5'
 gem 'blacklight', '~> 6.7'
 gem 'lcsort', '~> 0.9'
 gem 'trln_argon', git: 'https://github.com/trln/trln_argon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,6 +308,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable (~> 2.5)
   better_errors (= 2.1.1)
   blacklight (~> 6.7)
   byebug
@@ -336,4 +337,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.4
+   1.17.3

--- a/app/assets/stylesheets/dul_argon/sidebar.scss
+++ b/app/assets/stylesheets/dul_argon/sidebar.scss
@@ -30,6 +30,9 @@
   a.sidebar-thumb-link {
     cursor: default;
   }
+  .report-missing-item a {
+    font-size: 14px;
+  }
 
 
   ul.sidebar-menu {

--- a/app/helpers/report_missing_item_helper.rb
+++ b/app/helpers/report_missing_item_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ReportMissingItemHelper
+  def link_to_report_missing_item(options = {})
+    document = options.fetch(:document, nil)
+    return unless show_report_missing_item_link?(document)
+
+    link_to I18n.t('trln_argon.show.report_missing'),
+            report_missing_item_url(document),
+            target: '_blank'
+  end
+
+  private
+
+  def report_missing_item_params(document)
+    { 'BTITLE' => document.fetch(TrlnArgon::Fields::TITLE_MAIN,
+                                 'title unknown'),
+      'AUTHOR' => document.names.first.to_h.fetch(:name, ''),
+      'Q_JFE' => 'qdg' }
+  end
+
+  def report_missing_item_url(document)
+    report_missing_item_url_template.expand(
+      'query' => report_missing_item_params(document)
+    ).to_s
+  end
+
+  def report_missing_item_url_template
+    Addressable::Template.new(DulArgonSkin.report_missing_item_url)
+  end
+
+  def show_report_missing_item_link?(document)
+    DulArgonSkin.report_missing_item_url.present? &&
+      document.present? &&
+      document.record_owner == 'duke' &&
+      display_items?(document: document)
+  end
+end

--- a/app/views/catalog/_show_report_missing_item.html.erb
+++ b/app/views/catalog/_show_report_missing_item.html.erb
@@ -1,0 +1,3 @@
+<div class='report-missing-item'>
+  <%= link_to_report_missing_item(document: document) %>
+</div>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -11,4 +11,5 @@
   <hr/>
   <%= render :partial => 'show_sidebar_menu' %>
   <hr/>
+  <%= render :partial => 'show_report_missing_item', locals: { document: @document } %>
 </div>

--- a/config/initializers/dul_argon_skin.rb
+++ b/config/initializers/dul_argon_skin.rb
@@ -14,5 +14,6 @@ DulArgonSkin.configure do |config|
   config.map_location_service_url = ENV['MAP_LOCATION_SERVICE_URL']
   config.online_loc_b_codes = ENV['ONLINE_LOC_B_CODES'].split(', ')
   config.online_loc_n_codes = ENV['ONLINE_LOC_N_CODES'].split(', ')
+  config.report_missing_item_url = ENV['REPORT_MISSING_ITEM_URL']
   config.request_base_url = ENV['REQUEST_BASE_URL']
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,5 +85,6 @@ en:
         search_for_articles: 'Search for articles'
         suggest_a_purchase: 'Suggest a Purchase'
         request_link_html: "<a href='https://library.duke.edu/using/interlibrary-requests' target='_blank'>Request</a> books, articles and items unavailable at Duke through Interlibrary Requests"
+      report_missing: 'Report missing item'
     search_fields:
         shelfkey: 'Call Number (LC)'

--- a/lib/dul_argon_skin/configurable.rb
+++ b/lib/dul_argon_skin/configurable.rb
@@ -60,6 +60,12 @@ module DulArgonSkin
         ENV['ONLINE_LOC_N_CODES'] ||= 'FRDE, database, LINRE, PEI'
       end
 
+      # Report missing item URL template
+      mattr_accessor :report_missing_item_url do
+        ENV['REPORT_MISSING_ITEM_URL'] ||=
+          'https://duke.qualtrics.com/jfe/form/SV_71J91hwAk1B5YkR/{?query*}'
+      end
+
       # Request System base URL.
       mattr_accessor :request_base_url do
         ENV['REQUEST_BASE_URL'] ||= 'https://requests.library.duke.edu'

--- a/lib/dul_argon_skin/version.rb
+++ b/lib/dul_argon_skin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DulArgonSkin
-  VERSION = '0.4.5'
+  VERSION = '0.4.6'
 end

--- a/spec/helpers/report_missing_item_helper_spec.rb
+++ b/spec/helpers/report_missing_item_helper_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ReportMissingItemHelper do
+  describe '#link_to_report_missing_item' do
+    context 'when it is a Duke physical record' do
+      let(:document) do
+        SolrDocument.new(
+          id: 'DUKE0123456789',
+          title_main: 'The bond : a novel',
+          names_a: ['{"name":"Kirk, Robin","rel":"author"}'],
+          owner_a: ['duke'],
+          access_type_a: '["At the Library","Online"]',
+          items_a: ['{"loc_b":"PERKN","loc_n":"PK7","cn_scheme":"LC",'\
+                    '"call_no":"DS113 .J57 2019","type":"BOOK",'\
+                    '"item_id":"D05305040H","status":"On Hold"}']
+        )
+      end
+      let(:options) do
+        { document: document }
+      end
+      let(:response) do
+        '<a target="_blank" '\
+        'href="https://duke.qualtrics.com/jfe/form/SV_71J91hwAk1B5YkR/'\
+        '?BTITLE=The%20bond%20%3A%20a%20novel&amp;'\
+        'AUTHOR=Kirk%2C%20Robin&amp;Q_JFE=qdg">'\
+        'Report missing item</a>'
+      end
+
+      it 'generates link to report a missing item' do
+        expect(helper.link_to_report_missing_item(options)).to(
+          eq(response)
+        )
+      end
+    end
+
+    context 'when it is a Duke online record' do
+      let(:document) do
+        SolrDocument.new(
+          id: 'DUKE0123456789',
+          owner_a: ['duke'],
+          items_a: ['{"loc_b":"LAW","loc_n":"LINRE","cn_scheme":" ",'\
+                    '"call_no":"http://www.digital-law.net/IJCLP/index.html",'\
+                    '"type":"ITNET","status":"Available"}']
+        )
+      end
+      let(:options) do
+        { document: document }
+      end
+
+      it 'does not generate a link' do
+        expect(helper.link_to_report_missing_item(options)).to be_nil
+      end
+    end
+
+    context 'when it is a UNC record with a physical item' do
+      let(:document) do
+        SolrDocument.new(
+          id: 'UNC0123456789',
+          owner_a: ['unc'],
+          access_type_a: '["At the Library","Online"]',
+          items_a: ['{"item_id":"i2065349","loc_b":"trln","loc_n":"trln",'\
+                    '"status":"Available","cn_scheme":"LC",'\
+                    '"call_no":"PN1998.A2 L328","vol":"v.1"}']
+        )
+      end
+      let(:options) do
+        { document: document }
+      end
+
+      it 'does not generate a link' do
+        expect(helper.link_to_report_missing_item(options)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Link only displays if:
* there are physical items attached to the record
* the record is held by Duke
* there is a URL configured for the link