### PR TITLE
Boost English subject queries

### DIFF
--- a/app/models/concerns/english_subjects_boost.rb
+++ b/app/models/concerns/english_subjects_boost.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module EnglishSubjectsBoost
+  extend ActiveSupport::Concern
+
+  # A hack to deal with the fact that
+  # non-Roman subjects like to come up first
+  # since linked fields often duplicate English
+  # language subjects.
+  def english_subjects_boost(solr_parameters)
+    return unless includes_subject_search?
+    solr_parameters[:bq] = 'language_f:English^10000'
+  end
+
+  private
+
+  def includes_subject_search?
+    blacklight_params.key?('search_field') &&
+      (blacklight_params['search_field'] == 'subject' ||
+      (blacklight_params['search_field'] == 'advanced' &&
+      blacklight_params.fetch('subject', nil).present?))
+  end
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -7,9 +7,11 @@ class SearchBuilder < Blacklight::SearchBuilder
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
   include TrlnArgon::ArgonSearchBuilder
   include DulArgonSkin::ShelfkeySearchBuilder
+  include DulArgonSkin::EnglishSubjectsBoost
 
   self.default_processor_chain += %i[add_advanced_search_to_solr
-                                     add_shelfkey_query_to_solr]
+                                     add_shelfkey_query_to_solr
+                                     english_subjects_boost]
 
   ##
   # @example Adding a new step to the processor chain

--- a/lib/dul_argon_skin/version.rb
+++ b/lib/dul_argon_skin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DulArgonSkin
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -47,11 +47,57 @@ describe SearchBuilder do
     end
   end
 
+  describe '#english_subjects_boost' do
+    before do
+      builder_with_params.english_subjects_boost(solr_parameters)
+    end
+
+    context 'with a fielded subject search' do
+      let(:builder_with_params) do
+        subject.with(q: 'social surveys', 'search_field' => 'subject')
+      end
+
+      it 'adds an English language boost to the query' do
+        expect(solr_parameters[:bq]).to(
+          eq('language_f:English^10000')
+        )
+      end
+    end
+
+    context 'with a advanced subject search' do
+      let(:builder_with_params) do
+        subject.with(q: '',
+                     'search_field' => 'advanced',
+                     'subject' => 'social surveys')
+      end
+
+      it 'adds an English language boost to the query' do
+        expect(solr_parameters[:bq]).to(
+          eq('language_f:English^10000')
+        )
+      end
+    end
+
+    context 'with an all fields search' do
+      let(:builder_with_params) do
+        subject.with(q: 'social surveys', 'search_field' => 'all_fields')
+      end
+
+      it 'adds an English language boost to the query' do
+        expect(solr_parameters[:bq]).to be nil
+      end
+    end
+  end
+
   describe '#processor_chain' do
     let(:sb) { search_builder_class.new(CatalogController.new) }
 
     it 'adds the add_shelfkey_query_to_solr to the processor chain' do
       expect(sb.processor_chain).to include(:add_shelfkey_query_to_solr)
+    end
+
+    it 'adds the english_subjects_boost to the processor chain' do
+      expect(sb.processor_chain).to include(:english_subjects_boost)
     end
   end
 end


### PR DESCRIPTION
Gives a massive boost to English language material when a subject search is applied. This compensates for non-English material that frequently repeats English subject headings in the linked fields.