### PR TITLE
Prevent missing routes from filling the logs.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/trln/trln_argon
-  revision: 8498dae15da2aa4bea3e78d0efd128042add12df
+  revision: 0f24ef1ac2b92c9180282ad0fa532988e1c5f551
   specs:
-    trln_argon (1.0.4)
+    trln_argon (1.0.5)
       addressable (~> 2.5)
       blacklight (~> 6.16)
       blacklight-hierarchy (~> 1.1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,10 @@ class ApplicationController < ActionController::Base
   def default_url_options
     Rails.env.production? ? { protocol: :https } : {}
   end
+
+  def not_found
+    render file: 'public/404.html',
+           status: :not_found,
+           layout: false
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,5 +44,9 @@ Rails.application.routes.draw do
 
   resource :styleguide, only: [:show], as: 'styleguide', path: '/styleguide', controller: 'styleguide'
 
+
+  # IMPORTANT: This catch-all route should always be last.
+  match '/*path', to: 'application#not_found', via: :all
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/lib/dul_argon_skin/version.rb
+++ b/lib/dul_argon_skin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DulArgonSkin
-  VERSION = '1.0.7'
+  VERSION = '1.0.8'
 end


### PR DESCRIPTION
Also updates Argon to v1.0.5, which does better handling of failed advanced search query parsing.