### PR TITLE
Fiddle with the catch-all 404 response.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,7 @@ class ApplicationController < ActionController::Base
   end
 
   def not_found
+    response.content_type = Mime[:html]
     render file: 'public/404.html',
            status: :not_found,
            layout: false

--- a/lib/dul_argon_skin/version.rb
+++ b/lib/dul_argon_skin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DulArgonSkin
-  VERSION = '1.0.8'
+  VERSION = '1.0.9'
 end


### PR DESCRIPTION
Set MIME type to html because that's what's getting returned for any bad format request.