### PR TITLE
Update Argon to v1.0.6. Fixes Hathi links, etc.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/trln/trln_argon
-  revision: 0f24ef1ac2b92c9180282ad0fa532988e1c5f551
+  revision: 662a9adaa82490ea8b732700e8eb3e42dab7cc5d
   specs:
-    trln_argon (1.0.5)
+    trln_argon (1.0.6)
       addressable (~> 2.5)
       blacklight (~> 6.16)
       blacklight-hierarchy (~> 1.1.0)

--- a/lib/dul_argon_skin/version.rb
+++ b/lib/dul_argon_skin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DulArgonSkin
-  VERSION = '1.0.9'
+  VERSION = '1.0.10'
 end


### PR DESCRIPTION
See Argon release notes: https://github.com/trln/trln_argon/releases/tag/v1.0.6