### PR TITLE
Update Argon to v1.0.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/trln/trln_argon
-  revision: 944f0399e373b60e8221402953a98c84a2253f2f
+  revision: 926f32fae7f2d2cdb332f80effdb54f6ab7928c5
   specs:
-    trln_argon (1.0.11)
+    trln_argon (1.0.13)
       addressable (~> 2.5)
       blacklight (~> 6.16)
       blacklight-hierarchy (~> 1.1.0)

--- a/lib/dul_argon_skin/version.rb
+++ b/lib/dul_argon_skin/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DulArgonSkin
-  VERSION = '1.0.13'
+  VERSION = '1.0.14'
 end


### PR DESCRIPTION
Displays secondary link text instead of the href value.
Remove location facet selection when switching between local and TRLN results.