### PR TITLE
Updates to Adv. Search, Digitization linking, app config, and show fields.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -186,6 +186,30 @@ class CatalogController < ApplicationController
     # so we can add it again in the last position.
     isbn_issn = config.search_fields.delete('isbn_issn')
 
+    config.add_search_field('origin_place') do |field|
+      field.include_in_simple_select = false
+      field.label = I18n.t('trln_argon.search_fields.origin_place')
+      field.def_type = 'edismax'
+      field.solr_local_parameters = {
+        qf:  %w[origin_place_search_t^20
+                origin_place_search_ara_v
+                origin_place_search_cjk_v
+                origin_place_search_rus_v].join(' '),
+        pf:  %w[origin_place_search_t^80
+                origin_place_search_ara_v^20
+                origin_place_search_cjk_v^20
+                origin_place_search_rus_v^20].join(' '),
+        pf3: %w[origin_place_search_t^60
+                origin_place_search_ara_v^10
+                origin_place_search_cjk_v^10
+                origin_place_search_rus_v^10].join(' '),
+        pf2: %w[origin_place_search_t^40
+                origin_place_search_ara_v^5
+                origin_place_search_cjk_v^5
+                origin_place_search_rus_v^5].join(' ')
+      }
+    end
+
     config.add_search_field('series_statement') do |field|
       field.include_in_simple_select = false
       field.label = I18n.t('trln_argon.search_fields.series')
@@ -229,8 +253,11 @@ class CatalogController < ApplicationController
     config.add_search_field(isbn_issn)
 
     config.add_show_field TrlnArgon::Fields::LOCAL_ID.to_s,
-                          label: 'System ID',
-                          helper_method: 'strip_duke_id_prefix'
+                          label: TrlnArgon::Fields::LOCAL_ID.label,
+                          helper_method: :strip_duke_id_prefix
+    config.add_show_field TrlnArgon::Fields::DONOR.to_s,
+                          label: TrlnArgon::Fields::DONOR.label,
+                          helper_method: :add_donor_span
 
     config.show_fields[TrlnArgon::Fields::NOTE_LOCAL]
           .helper_method = :add_bookplate_span

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,6 +54,12 @@ module ApplicationHelper
     end.join('<br/>').html_safe
   end
 
+  def add_donor_span(options = {})
+    options.fetch(:value, []).map do |v|
+      content_tag(:span, v, class: 'dul-bookplate')
+    end.join('<br/>').html_safe
+  end
+
   private
 
   def bookplate_regex

--- a/config/initializers/dul_argon_skin.rb
+++ b/config/initializers/dul_argon_skin.rb
@@ -1,24 +1,2 @@
 # frozen_string_literal: true
 require 'dul_argon_skin'
-
-DulArgonSkin.configure do |config|
-  # Configs unique to local skin, separate from TrlnArgon
-  config.about_url = ENV['ABOUT_URL']
-  config.dul_home_url = ENV['DUL_HOME_URL']
-  config.environment_alert = ENV['ENVIRONMENT_ALERT']
-  config.google_analytics_debug = ENV['GOOGLE_ANALYTICS_DEBUG']
-  config.google_analytics_tracking_id = ENV['GOOGLE_ANALYTICS_TRACKING_ID']
-  config.illiad_dul_base_url = ENV['ILLIAD_DUL_BASE_URL']
-  config.illiad_law_base_url = ENV['ILLIAD_LAW_BASE_URL']
-  config.illiad_ford_base_url = ENV['ILLIAD_FORD_BASE_URL']
-  config.illiad_med_base_url = ENV['ILLIAD_MED_BASE_URL']
-  config.map_location_service_url = ENV['MAP_LOCATION_SERVICE_URL']
-  config.online_loc_b_codes = ENV['ONLINE_LOC_B_CODES'].split(', ')
-  config.online_loc_n_codes = ENV['ONLINE_LOC_N_CODES'].split(', ')
-  config.report_missing_item_url = ENV['REPORT_MISSING_ITEM_URL']
-  config.request_base_url = ENV['REQUEST_BASE_URL']
-  config.request_digitization_url = ENV['REQUEST_DIGITIZATION_URL']
-  config.req_digi_loc_b_codes = ENV['REQ_DIGI_LOC_B_CODES']
-  config.req_digi_loc_n_codes = ENV['REQ_DIGI_LOC_N_CODES']
-  config.search_tips_url = ENV['SEARCH_TIPS_URL']
-end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,8 +141,9 @@ en:
     latest_received:
       link_text: "Latest received"
     search_fields:
-        call_number: 'Call Number (LC)'
+        call_number: 'Call Number'
         series: 'Series'
+        origin_place: 'Place of Publication'
     advanced_search:
       help:
         title: 'Search tips'

--- a/config/solr_field_overrides.yml
+++ b/config/solr_field_overrides.yml
@@ -7,10 +7,18 @@
 #   label:
 #     en: Director
 
+DONOR:
+  solr_field: :donor_a
+  label:
+    en: Bookplate
 LC_CALL_NOS_NORMED:
   solr_field: :lc_call_nos_normed_a
   label:
     en: LCC Normed
+LOCAL_ID:
+  solr_field: :local_id
+  label:
+    en: System ID
 TITLE_MAIN_INDEXED:
   solr_field: :title_main_indexed_t
   label:
@@ -20,6 +28,8 @@ SHELFKEY:
   label:
       en: Shelfkey
 SHELF_NUMBERS:
-    solr_field: shelf_numbers_tp
-    label:
-      en: Shelf Number
+  solr_field: shelf_numbers_tp
+  label:
+    en: Shelf Number
+
+

--- a/lib/dul_argon_skin/configurable.rb
+++ b/lib/dul_argon_skin/configurable.rb
@@ -6,94 +6,96 @@ module DulArgonSkin
     # rubocop:disable Metrics/BlockLength
     included do
       mattr_accessor :dul_home_url do
-        ENV['DUL_HOME_URL'] ||= 'https://library.duke.edu'
+        ENV['DUL_HOME_URL'] || 'https://library.duke.edu'
       end
 
       # If present this string will display in a banner alert
       # at the top of each page to indicate which environment
       # the application is running in. Banner alert NOT shown if blank.
       mattr_accessor :environment_alert do
-        ENV['ENVIRONMENT_ALERT'] ||= ''
+        ENV['ENVIRONMENT_ALERT'] || ''
       end
 
       # If 'true', output the data being sent to Google Analytics in
       # the browser console.
       mattr_accessor :google_analytics_debug do
-        ENV['GOOGLE_ANALYTICS_DEBUG'] ||= 'false'
+        ENV['GOOGLE_ANALYTICS_DEBUG'] || 'false'
       end
 
       # If tracking ID is present, activate Google Analytics tracking
       # and use that ID.
       mattr_accessor :google_analytics_tracking_id do
-        ENV['GOOGLE_ANALYTICS_TRACKING_ID'] ||= ''
+        ENV['GOOGLE_ANALYTICS_TRACKING_ID'] || ''
       end
 
       # ILLiad base URLs for DUL & professional school libraries.
       # =========================================================
       mattr_accessor :illiad_dul_base_url do
-        ENV['ILLIAD_DUL_BASE_URL'] ||= 'https://duke-illiad-oclc-org.proxy.lib.duke.edu/illiad/NDD/illiad.dll'
+        ENV['ILLIAD_DUL_BASE_URL'] || 'https://duke-illiad-oclc-org.proxy.lib.duke.edu/illiad/NDD/illiad.dll'
       end
 
       mattr_accessor :illiad_law_base_url do
-        ENV['ILLIAD_LAW_BASE_URL'] ||= 'https://duke-illiad-oclc-org.proxy.lib.duke.edu/illiad/NDL/illiad.dll'
+        ENV['ILLIAD_LAW_BASE_URL'] || 'https://duke-illiad-oclc-org.proxy.lib.duke.edu/illiad/NDL/illiad.dll'
       end
 
       mattr_accessor :illiad_ford_base_url do
-        ENV['ILLIAD_FORD_BASE_URL'] ||= 'https://duke-illiad-oclc-org.proxy.lib.duke.edu/illiad/NDB/illiad.dll'
+        ENV['ILLIAD_FORD_BASE_URL'] || 'https://duke-illiad-oclc-org.proxy.lib.duke.edu/illiad/NDB/illiad.dll'
       end
 
       mattr_accessor :illiad_med_base_url do
-        ENV['ILLIAD_MED_BASE_URL'] ||= 'https://illiad.mclibrary.duke.edu/illiad.dll'
+        ENV['ILLIAD_MED_BASE_URL'] || 'https://illiad.mclibrary.duke.edu/illiad.dll'
       end
 
       mattr_accessor :map_location_service_url do
-        ENV['MAP_LOCATION_SERVICE_URL'] ||= 'https://library.duke.edu/locguide/mapinfo'
+        ENV['MAP_LOCATION_SERVICE_URL'] || 'https://library.duke.edu/locguide/mapinfo'
       end
 
       # Broad and narrow location codes that indicate online items.
       # =========================================================
       mattr_accessor :online_loc_b_codes do
-        ENV['ONLINE_LOC_B_CODES'] ||= 'ONLINE, DUKIR'
+        (ENV['ONLINE_LOC_B_CODES'] || 'ONLINE, DUKIR').split(', ')
       end
 
       mattr_accessor :online_loc_n_codes do
-        ENV['ONLINE_LOC_N_CODES'] ||= 'FRDE, database, LINRE, PEI, PENTL, MELEC'
+        (ENV['ONLINE_LOC_N_CODES'] ||
+          'FRDE, database, LINRE, PEI, PENTL, MELEC').split(', ')
       end
 
       # Report missing item URL template
       mattr_accessor :report_missing_item_url do
-        ENV['REPORT_MISSING_ITEM_URL'] ||=
+        ENV['REPORT_MISSING_ITEM_URL'] ||
           'https://duke.qualtrics.com/jfe/form/SV_71J91hwAk1B5YkR/{?query*}'
       end
 
       # Request System base URL.
       mattr_accessor :request_base_url do
-        ENV['REQUEST_BASE_URL'] ||= 'https://requests.library.duke.edu'
+        ENV['REQUEST_BASE_URL'] || 'https://requests.library.duke.edu'
       end
 
       # Digitization request configurations
       # =========================================================
       mattr_accessor :request_digitization_url do
-        ENV['REQUEST_DIGITIZATION_URL'] ||=
+        ENV['REQUEST_DIGITIZATION_URL'] ||
           'https://duke.qualtrics.com/jfe/form/SV_9MOS64T5GlJ5bY9{?query*}'
       end
 
       mattr_accessor :req_digi_loc_b_codes do
-        ENV['REQ_DIGI_LOC_B_CODES'] ||= 'PERKN, LILLY, MARIN, MUSIC, DOCS'
+        (ENV['REQ_DIGI_LOC_B_CODES'] ||
+          'PERKN, LILLY, MARIN, MUSIC, DOCS').split(', ')
       end
 
       mattr_accessor :req_digi_loc_n_codes do
-        ENV['REQ_DIGI_LOC_N_CODES'] ||= 'PSB, PSL, PSK, PSM'
+        (ENV['REQ_DIGI_LOC_N_CODES'] || 'PSB, PSL, PSK, PSM').split(', ')
       end
 
       # Search tips URL.
       mattr_accessor :search_tips_url do
-        ENV['SEARCH_TIPS_URL'] ||= 'https://library.duke.edu/using/catalog-search-tips'
+        ENV['SEARCH_TIPS_URL'] || 'https://library.duke.edu/using/catalog-search-tips'
       end
 
       # About URL.
       mattr_accessor :about_url do
-        ENV['ABOUT_URL'] ||= 'https://blogs.library.duke.edu/bitstreams/2019/01/07/new-duke-libraries-catalog-to-go-live-january-16/'
+        ENV['ABOUT_URL'] || 'https://blogs.library.duke.edu/bitstreams/2019/01/07/new-duke-libraries-catalog-to-go-live-january-16/'
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -12,6 +12,34 @@ describe CatalogController do
     end
   end
 
+  describe 'show_fields' do
+    describe 'local_id' do
+      it 'sets the local_id field to display' do
+        expect(config.show_fields).to have_key('local_id')
+      end
+
+      it 'has a label for local_id' do
+        expect(config.show_fields['local_id'].label).to eq('System ID')
+      end
+    end
+
+    describe 'donor' do
+      it 'sets the donor field to display' do
+        expect(config.show_fields).to have_key('donor_a')
+      end
+
+      it 'has a label for donor' do
+        expect(config.show_fields['donor_a'].label).to eq('Bookplate')
+      end
+
+      it 'applies the donor span helper method' do
+        expect(config.show_fields['donor_a'].helper_method).to(
+          eq(:add_donor_span)
+        )
+      end
+    end
+  end
+
   describe 'search fields' do
     describe 'call_number' do
       it 'sets the call_number field' do
@@ -20,13 +48,55 @@ describe CatalogController do
 
       it 'has a label for the call_number field' do
         expect(config.search_fields['call_number'].label).to(
-          eq('Call Number (LC)')
+          eq('Call Number')
         )
       end
     end
 
-    # rubocop:disable RSpec/ExampleLength
+    describe 'origin_place' do
+      let(:solr_params_exp) do
+        YAML.safe_load(
+          file_fixture('solr_parameters/origin_place_exp.yml').read, [Symbol]
+        )
+      end
+
+      it 'sets the origin_place field' do
+        expect(config.search_fields).to have_key('origin_place')
+      end
+
+      it 'has a label for the series field' do
+        expect(config.search_fields['origin_place'].label).to(
+          eq('Place of Publication')
+        )
+      end
+
+      it 'is excluded from simple select dropdown' do
+        expect(
+          config.search_fields['origin_place'].include_in_simple_select
+        ).to be false
+      end
+
+      it 'sets the correct Solr defType' do
+        expect(config.search_fields['origin_place'].def_type).to(
+          eq('edismax')
+        )
+      end
+
+      it 'sets the solr local parameters' do
+        expect(
+          config.search_fields['origin_place'].solr_local_parameters
+        ).to eq(solr_params_exp)
+      end
+    end
+
     describe 'series_statement' do
+      let(:solr_params_exp) do
+        YAML.safe_load(
+          file_fixture('solr_parameters/series_statement_exp.yml').read,
+          [Symbol]
+        )
+      end
+
       it 'sets the series_statement field' do
         expect(config.search_fields).to have_key('series_statement')
       end
@@ -50,44 +120,10 @@ describe CatalogController do
       it 'sets the solr local parameters' do
         expect(
           config.search_fields['series_statement'].solr_local_parameters
-        ).to(
-          eq(qf:  'series_work_indexed_t^20 '\
-                  'series_work_indexed_ara_v '\
-                  'series_work_indexed_cjk_v '\
-                  'series_work_indexed_rus_v '\
-                  'series_statement_indexed_t^20 '\
-                  'series_statement_indexed_cjk_v '\
-                  'series_statement_indexed_ara_v '\
-                  'series_statement_indexed_rus_v',
-             pf:  'series_work_indexed_t^80 '\
-                  'series_work_indexed_ara_v^20 '\
-                  'series_work_indexed_cjk_v^20 '\
-                  'series_work_indexed_rus_v^20 '\
-                  'series_statement_indexed_t^80 '\
-                  'series_statement_indexed_cjk_v^20 '\
-                  'series_statement_indexed_ara_v^20 '\
-                  'series_statement_indexed_rus_v^20',
-             pf3: 'series_work_indexed_t^60 '\
-                  'series_work_indexed_ara_v^10 '\
-                  'series_work_indexed_cjk_v^10 '\
-                  'series_work_indexed_rus_v^10 '\
-                  'series_statement_indexed_t^60 '\
-                  'series_statement_indexed_cjk_v^10 '\
-                  'series_statement_indexed_ara_v^10 '\
-                  'series_statement_indexed_rus_v^10',
-             pf2: 'series_work_indexed_t^40 '\
-                  'series_work_indexed_ara_v^5 '\
-                  'series_work_indexed_cjk_v^5 '\
-                  'series_work_indexed_rus_v^5 '\
-                  'series_statement_indexed_t^40 '\
-                  'series_statement_indexed_cjk_v^5 '\
-                  'series_statement_indexed_ara_v^5 '\
-                  'series_statement_indexed_rus_v^5')
-        )
+        ).to eq(solr_params_exp)
       end
     end
   end
-  # rubocop:enable RSpec/ExampleLength
 
   describe 'home facet fields' do
     it 'sets the access type facet' do

--- a/spec/fixtures/files/solr_parameters/origin_place_exp.yml
+++ b/spec/fixtures/files/solr_parameters/origin_place_exp.yml
@@ -1,0 +1,9 @@
+---
+:qf: origin_place_search_t^20 origin_place_search_ara_v origin_place_search_cjk_v
+  origin_place_search_rus_v
+:pf: origin_place_search_t^80 origin_place_search_ara_v^20 origin_place_search_cjk_v^20
+  origin_place_search_rus_v^20
+:pf3: origin_place_search_t^60 origin_place_search_ara_v^10 origin_place_search_cjk_v^10
+  origin_place_search_rus_v^10
+:pf2: origin_place_search_t^40 origin_place_search_ara_v^5 origin_place_search_cjk_v^5
+  origin_place_search_rus_v^5

--- a/spec/fixtures/files/solr_parameters/series_statement_exp.yml
+++ b/spec/fixtures/files/solr_parameters/series_statement_exp.yml
@@ -1,0 +1,13 @@
+---
+:qf: series_work_indexed_t^20 series_work_indexed_ara_v series_work_indexed_cjk_v series_work_indexed_rus_v
+  series_statement_indexed_t^20 series_statement_indexed_cjk_v series_statement_indexed_ara_v
+  series_statement_indexed_rus_v
+:pf: series_work_indexed_t^80 series_work_indexed_ara_v^20 series_work_indexed_cjk_v^20
+  series_work_indexed_rus_v^20 series_statement_indexed_t^80 series_statement_indexed_cjk_v^20
+  series_statement_indexed_ara_v^20 series_statement_indexed_rus_v^20
+:pf3: series_work_indexed_t^60 series_work_indexed_ara_v^10 series_work_indexed_cjk_v^10
+  series_work_indexed_rus_v^10 series_statement_indexed_t^60 series_statement_indexed_cjk_v^10
+  series_statement_indexed_ara_v^10 series_statement_indexed_rus_v^10
+:pf2: series_work_indexed_t^40 series_work_indexed_ara_v^5 series_work_indexed_cjk_v^5
+  series_work_indexed_rus_v^5 series_statement_indexed_t^40 series_statement_indexed_cjk_v^5
+  series_statement_indexed_ara_v^5 series_statement_indexed_rus_v^5

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -175,4 +175,18 @@ describe ApplicationHelper do
       )
     end
   end
+
+  describe 'add_donor_span' do
+    let(:value) do
+      { value: ['Acquired as part of the Leona Bowman Carpenter Collection'] }
+    end
+
+    it 'wraps the donor note in a span' do
+      expect(add_donor_span(value)).to(
+        eq('<span class="dul-bookplate">'\
+           'Acquired as part of the Leona Bowman Carpenter Collection'\
+           '</span>')
+      )
+    end
+  end
 end

--- a/spec/helpers/request_digitization_helper_spec.rb
+++ b/spec/helpers/request_digitization_helper_spec.rb
@@ -13,6 +13,7 @@ describe RequestDigitizationHelper do
           owner_a: ['duke'],
           publication_year_sort: '1943',
           resource_type_a: ['Book'],
+          physical_media_a: ['Print'],
           access_type_a: ['At the Library'],
           items_a: ['{"loc_b":"PERKN","loc_n":"PK","cn_scheme":"LC",'\
                     '"call_no":"Z4 .M15 1943","type":"BOOK",'\
@@ -46,6 +47,7 @@ describe RequestDigitizationHelper do
           owner_a: ['duke'],
           publication_year_sort: '1922',
           resource_type_a: ['Book'],
+          physical_media_a: ['Print'],
           access_type_a: ['At the Library', 'Online'],
           items_a: ['{"loc_b":"PERKN","loc_n":"PK","cn_scheme":"LC",'\
                     '"call_no":"PZ3.C107 Ju3 1922","type":"BOOK",'\
@@ -78,6 +80,7 @@ describe RequestDigitizationHelper do
           owner_a: ['duke'],
           publication_year_sort: '1973',
           resource_type_a: ['Book'],
+          physical_media_a: ['Print'],
           access_type_a: ['At the Library'],
           items_a: ['{"loc_b":"PERKN","loc_n":"PK","cn_scheme":"LC",'\
                     '"call_no":"PS3554.E437 D48 2001","type":"BOOK",'\
@@ -99,6 +102,7 @@ describe RequestDigitizationHelper do
           owner_a: ['duke'],
           publication_year_sort: '1943',
           resource_type_a: ['Journal, Magazine, or Periodical'],
+          physical_media_a: ['Print'],
           access_type_a: ['At the Library'],
           items_a: ['{"loc_b":"PERKN","loc_n":"PK","cn_scheme":"LC",'\
                     '"call_no":"D808 .A365",'\
@@ -120,10 +124,33 @@ describe RequestDigitizationHelper do
           owner_a: ['duke'],
           publication_year_sort: '1943',
           resource_type_a: ['Book'],
+          physical_media_a: ['Print'],
           access_type_a: ['At the Library'],
           items_a: ['{"loc_b":"SCL","loc_n":"PRSBQ","cn_scheme":"LC",'\
                     '"call_no":"TX715 .R62 1943",'\
                     '"item_id":"D03022111A","status":"Available"}']
+        )
+      end
+
+      it 'does not pass the eligibility check' do
+        expect(helper.show_request_digitization_link?(document)).to be false
+      end
+    end
+
+    context 'when it has a physical media format of Microform' do
+      let(:document) do
+        SolrDocument.new(
+          id: 'DUKE008746259',
+          local_id: 'DUKE008746259',
+          title_main: 'Jurgen; a comedy of justice',
+          owner_a: ['duke'],
+          publication_year_sort: '1922',
+          resource_type_a: ['Book'],
+          physical_media_a: ['Print', 'Microform > Microfiche'],
+          access_type_a: ['At the Library', 'Online'],
+          items_a: ['{"loc_b":"PERKN","loc_n":"PK","cn_scheme":"LC",'\
+                    '"call_no":"PZ3.C107 Ju3 1922","type":"BOOK",'\
+                    '"item_id":"D05278727","status":"Available"}']
         )
       end
 


### PR DESCRIPTION
Addresses the following issues:

CAT2-159 (partially) -- setup to display donor_a once it's populated in the index.
CAT2-111 -- Adds place of publication to the advanced search fields
CAT2-139 -- Removes "LC" from "Call Number" search field drop down
CAT2-167 -- Exclude non-Print and Microform material from digitization request button
CAT2-165 -- Simplify the application configuration setup.